### PR TITLE
feat(mem): restart firefox when memory limit reached

### DIFF
--- a/firefox.god
+++ b/firefox.god
@@ -2,4 +2,11 @@ God.watch do |w|
   w.name = "Firefox"
   w.start = "/usr/bin/firefox-dev -headless -marionette -profile /home/firefox/profile/"
   w.keepalive
+  w.transition(:up, :restart) do |on|
+    on.condition(:memory_usage) do |c|
+      c.interval = 20
+      c.above = ENV.fetch("FF_MEM_LIMIT", "500").to_i.megabytes
+      c.times = [3, 5]
+    end
+  end
 end


### PR DESCRIPTION
Default limit is 500Mb, it is can be redefined with env variable `FF_MEM_LIMIT` 

[NLJ-1657]

[NLJ-1657]: https://team-1602965683919.atlassian.net/browse/NLJ-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ