### PR TITLE
feat: ff children eye monitoring

### DIFF
--- a/firefox.eye
+++ b/firefox.eye
@@ -7,11 +7,13 @@ end
 Eye.application :firefox do
   working_dir ROOT
   trigger :flapping, times: 10, within: 1.minute
+  # currently we do not want monitor the cpu it is only for logs
+  check :cpu, every: 30, below: 10000, times: 6
 
   process :marionette do
-    daemonize true
     pid_file 'marionette.pid'
-    stdall 'marionette.log'
+    stdall '/dev/null'
+    daemonize true
 
     start_command "/usr/bin/firefox-dev -headless -marionette -profile /home/firefox/profile/"
 
@@ -22,9 +24,14 @@ Eye.application :firefox do
     # (maybe enought to firefox soft restart)
     restart_grace 5.seconds
 
-    # currently we not monitor the cpu
-    # check :cpu, every: 30, below: 90, times: 3
+    check :memory, every: 30, below: 350.megabytes, times: [3, 5]
+    # with option below will calculate all children memory and kill marionette process
+    # check :children_memory, every: 15, below: 450.megabytes, times: [3, 5]
 
-    check :memory, every: 30, below: 800.megabytes, times: [3, 5]
+    monitor_children do
+      stop_command 'kill -QUIT {PID}'
+      # with option below will calculate each child memory and kill child process
+      check :memory, every: 10, below: 200.megabytes, times: [3, 5]
+    end
   end
 end

--- a/profile/prefs.js
+++ b/profile/prefs.js
@@ -142,3 +142,4 @@ user_pref("browser.cache.disk.enable", false);
 user_pref("browser.cache.memory.enable", false);
 user_pref("browser.cache.offline.enable", false);
 user_pref("network.http.use-cache", false);
+user_pref("browser.cache.disk.capacity", 0);


### PR DESCRIPTION
```
2021.11.12 20:24:19 INFO  -- [firefox:marionette] check:cpu(<10000%) [0%, 0%, 0%, 0%, 0%] => OK
2021.11.12 20:24:19 INFO  -- [firefox:marionette] check:memory(<350Mb) [317Mb, 317Mb, 317Mb, 317Mb, 318Mb] => OK
2021.11.12 20:24:19 INFO  -- [firefox:marionette:child-760170] check:memory(<200Mb) [73Mb, 73Mb, 73Mb, 73Mb, 73Mb] => OK
2021.11.12 20:24:19 INFO  -- [firefox:marionette:child-761895] check:memory(<200Mb) [163Mb, 163Mb, 163Mb, 163Mb, 163Mb] => OK
2021.11.12 20:24:19 INFO  -- [firefox:marionette:child-761917] check:memory(<200Mb) [59Mb, 59Mb, 59Mb, 59Mb, 59Mb] => OK
```