### PR TITLE
fix(ci): Push image only from master branch

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: 0 0 * * 3
   push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,14 @@
+name: PR check
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build Docker image
+        run: docker build . --file Dockerfile


### PR DESCRIPTION
Previously any CI pushed docker image from any branch in repo.
So developer may acidentely replace firefox even on production just by
creating working branch.