### PR TITLE
fix: docker image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:focal
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends --yes install firefox=98\* dumb-init curl build-essential ruby ruby-dev gem socat wget fontconfig && \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends --yes install dumb-init curl build-essential ruby ruby-dev gem socat wget fontconfig && \
     groupadd firefox && \
     useradd --create-home --gid firefox firefox && \
     chown --recursive firefox:firefox /home/firefox/

--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@ Dockerized Firefox in headless [Marionette](https://vakila.github.io/blog/marion
 ## Usage
 # build
 ```sh
-docker pull deepsweet/firefox-headless-remote:68
-docker run -it --rm --shm-size 2g -p 2828:2828 deepsweet/firefox-headless-remote:68
+docker build -t firefox-headless . 
+docker run -it --rm --shm-size 2g -p 2828:2828 firefox-headless
 ```
 
 Example using [Foxr](https://github.com/deepsweet/foxr):


### PR DESCRIPTION
Fixed docker image build by deleting downloading specific Firefox version from PPA repository before downloading the specific firefox by CURL.